### PR TITLE
Switch project to C#/.NET

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Ignore build outputs
+bin/
+obj/
+# Visual Studio files
+.vs/
+*.user
+*.suo
+
+# Dotnet artifacts
+*/bin/
+*/obj/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # LightReplacer
-Um aplicativo que renomeia arquivos.
-Com tradução e mais!
 
-LighReplacerV0.16: [LightReplacer.zip](https://github.com/user-attachments/files/17189280/LightReplacer.zip)
+Projeto atualizado para C# e .NET. Agora o utilitário pode ser compilado e executado em qualquer plataforma suportada pelo .NET 8.
+
+## Requisitos
+- .NET 8 SDK
+
+## Como compilar
+```bash
+cd src/LightReplacerCS
+ dotnet build
+```
+
+## Como usar
+```
+dotnet run -- <arquivos> [-n nome] [--upper|--lower] [--translate origem destino]
+```
+
+Exemplo:
+```
+dotnet run -- arquivo.txt -n NovoNome --upper --translate pt en
+```

--- a/src/LightReplacerCS/LightReplacerCS.csproj
+++ b/src/LightReplacerCS/LightReplacerCS.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/LightReplacerCS/Program.cs
+++ b/src/LightReplacerCS/Program.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace LightReplacerCS
+{
+    class Program
+    {
+        static async Task<int> Main(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                Console.WriteLine("Usage: LightReplacerCS <file1> [file2 ...] [-n newname] [--upper|--lower] [--translate src dest]");
+                return 1;
+            }
+
+            var files = new List<string>();
+            string? renamePattern = null;
+            bool toUpper = false;
+            bool toLower = false;
+            string? srcLang = null;
+            string? dstLang = null;
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                switch (args[i])
+                {
+                    case "-n":
+                    case "--name":
+                        if (i + 1 < args.Length)
+                        {
+                            renamePattern = args[++i];
+                        }
+                        break;
+                    case "--upper":
+                        toUpper = true;
+                        break;
+                    case "--lower":
+                        toLower = true;
+                        break;
+                    case "--translate":
+                        if (i + 2 < args.Length)
+                        {
+                            srcLang = args[++i];
+                            dstLang = args[++i];
+                        }
+                        break;
+                    default:
+                        files.Add(args[i]);
+                        break;
+                }
+            }
+
+            if (files.Count == 0)
+            {
+                Console.WriteLine("No files specified.");
+                return 1;
+            }
+
+            var newNames = new List<string>();
+            int counter = 1;
+            foreach (var file in files)
+            {
+                var dir = Path.GetDirectoryName(file) ?? string.Empty;
+                var name = Path.GetFileName(file);
+                if (renamePattern != null)
+                {
+                    var ext = Path.GetExtension(name);
+                    name = $"{renamePattern}{counter}{ext}";
+                    counter++;
+                }
+
+                if (toUpper)
+                {
+                    var ext = Path.GetExtension(name);
+                    name = Path.GetFileNameWithoutExtension(name).ToUpper() + ext;
+                }
+                else if (toLower)
+                {
+                    var ext = Path.GetExtension(name);
+                    name = Path.GetFileNameWithoutExtension(name).ToLower() + ext;
+                }
+
+                newNames.Add(Path.Combine(dir, name));
+            }
+
+            if (srcLang != null && dstLang != null)
+            {
+                for (int i = 0; i < newNames.Count; i++)
+                {
+                    var ext = Path.GetExtension(newNames[i]);
+                    var nameOnly = Path.GetFileNameWithoutExtension(newNames[i]);
+                    var translated = await TranslateName(nameOnly, srcLang, dstLang);
+                    newNames[i] = Path.Combine(Path.GetDirectoryName(newNames[i]) ?? string.Empty, translated + ext);
+                }
+            }
+
+            for (int i = 0; i < files.Count; i++)
+            {
+                File.Move(files[i], newNames[i]);
+                Console.WriteLine($"Renamed {files[i]} -> {newNames[i]}");
+            }
+
+            return 0;
+        }
+
+        static async Task<string> TranslateName(string text, string src, string dest)
+        {
+            try
+            {
+                using var client = new HttpClient();
+                var url = $"https://translate.googleapis.com/translate_a/single?client=gtx&sl={src}&tl={dest}&dt=t&q={Uri.EscapeDataString(text)}";
+                var response = await client.GetStringAsync(url);
+                using var doc = JsonDocument.Parse(response);
+                return doc.RootElement[0][0][0].GetString() ?? text;
+            }
+            catch
+            {
+                return text;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- migrate LightReplacer to a C#/.NET console application
- add build instructions and usage info in Portuguese
- add .gitignore for .NET

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_683f9a285b2c8333a0c6d7306b7ab567